### PR TITLE
Reflect most recent title and author list of security analysis in the references

### DIFF
--- a/draft-irtf-cfrg-randomness-improvements.md
+++ b/draft-irtf-cfrg-randomness-improvements.md
@@ -89,10 +89,10 @@ normative:
                 ins: LaMacchia, Brian et al.
         target: https://www.microsoft.com/en-us/research/wp-content/uploads/2016/02/strongake-submitted.pdf
     SecAnalysis:
-        title: Security Analysis for Randomness Improvements for Security Protocols
+        title: Limiting the impact of unreliable randomness in deployed security protocols
         author:
             -
-                ins: Akhmetzyanova, Cremers, Garratt, Smyshlyaev
+                ins: Akhmetzyanova, Cremers, Garratt, Smyshlyaev, Sullivan
         target: https://eprint.iacr.org/2018/1057
     RY2010:
         title: When Good Randomness Goes Bad|:| Virtual Machine Reset Vulnerabilities and Hedging Deployed Cryptography


### PR DESCRIPTION
The security analysis document expanded substantially. As a result, the title
changed, and Nick Sullivan was added as an author. Pushing this change
into the references list.